### PR TITLE
Fix flickering when using Forest's volume panel

### DIFF
--- a/forest/index.css
+++ b/forest/index.css
@@ -71,10 +71,6 @@
   display: none;
 }
 
-.vjs-theme-forest .vjs-volume-panel.vjs-volume-panel-horizontal:active {
-  width: auto;
-}
-
 .vjs-theme-forest .vjs-volume-panel {
   margin-left: 0.5em;
   margin-right: 0.5em;

--- a/forest/index.css
+++ b/forest/index.css
@@ -71,6 +71,10 @@
   display: none;
 }
 
+.vjs-theme-forest .vjs-volume-panel.vjs-volume-panel-horizontal:active {
+  width: auto;
+}
+
 .vjs-theme-forest .vjs-volume-panel {
   margin-left: 0.5em;
   margin-right: 0.5em;
@@ -82,6 +86,7 @@
 .vjs-theme-forest .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal,
 .vjs-theme-forest .vjs-volume-panel:active .vjs-volume-control.vjs-volume-horizontal,
 .vjs-theme-forest .vjs-volume-panel.vjs-volume-panel-horizontal:hover,
+.vjs-theme-forest .vjs-volume-panel.vjs-volume-panel-horizontal.vjs-slider-active,
 .vjs-theme-forest .vjs-volume-bar.vjs-slider-horizontal {
   width: 3em;
 }


### PR DESCRIPTION
Thanks to a missed selector, the volume control would occasionally cost the progress bar to flicker or get pushed over.