### PR TITLE
Remove reference to city theme in fantasy theme

### DIFF
--- a/fantasy/index.css
+++ b/fantasy/index.css
@@ -49,10 +49,6 @@
   margin-top: 2.5em;
 }
 
-.vjs-theme-city .vjs-volume-panel:hover .vjs-volume-control.vjs-volume-horizontal {
-  height: 100%;
-}
-
 .vjs-theme-fantasy .vjs-progress-control .vjs-progress-holder {
   font-size: 1.5em;
 }


### PR DESCRIPTION
There appears to be a stray reference to the city theme inside of the fantasy theme. Not a significant problem but here is a PR that removes, if you would like it.

This could be a typo in the CSS class name also, however fixing it this way doesn't appear to have an effect on the volume panel.